### PR TITLE
Added formatting option to omit timeframe generating params if they're not set

### DIFF
--- a/lookmlgen/base_generator.py
+++ b/lookmlgen/base_generator.py
@@ -21,20 +21,28 @@ class GeneratorFormatOptions(object):
     :param warning_header_comment: Text to use as a comment as the top
                                    of the file warning the user that the
                                    file will get overwritten
+    :param omit_time_frames_if_not_set: If no time frame is specified for
+                                        a dimension_group field, omit the
+                                        time_frames parameter. If timeframes
+                                        is not included every timeframe
+                                        option will be added to the dimension group.
     :type indent_spaces: int
     :type newline_between_items: bool
     :type omit_default_field_type: bool
     :type warning_header_comment: string
+    :type omit_time_frames_if_not_set: bool
 
     """
     def __init__(self, indent_spaces=2, newline_between_items=True,
                  omit_default_field_type=True, view_fields_alphabetical=True,
-                 warning_header_comment=DEFAULT_WARNING_HEADER_COMMENT):
+                 warning_header_comment=DEFAULT_WARNING_HEADER_COMMENT,
+                 omit_time_frames_if_not_set=False):
         self.indent_spaces = indent_spaces
         self.newline_between_items = newline_between_items
         self.omit_default_field_type = omit_default_field_type
         self.warning_header_comment = warning_header_comment
         self.view_fields_alphabetical = view_fields_alphabetical
+        self.omit_time_frames_if_not_set = omit_time_frames_if_not_set
 
 
 @six.add_metaclass(abc.ABCMeta)

--- a/lookmlgen/field.py
+++ b/lookmlgen/field.py
@@ -137,13 +137,13 @@ class DimensionGroup(Field):
     def __init__(self, name, timeframes=None, datatype='datetime', **kwargs):
         super(DimensionGroup, self).__init__(FieldType.DIMENSION_GROUP, name,
                                              type='time', **kwargs)
-        if not timeframes:
-            self.timeframes = ['time', 'date', 'week', 'month']
-        else:
-            self.timeframes = timeframes
+        self.timeframes = timeframes
         self.datatype = datatype
 
     def _generate(self, f, fo):
+        if not self.timeframes and not fo.omit_time_frames_if_not_set:
+            self.timeframes = ['time', 'date', 'week', 'month']
+
         if self.timeframes:
             f.write('{indent}timeframes: {timeframes}\n'.
                     format(indent=' ' * 2 * fo.indent_spaces,

--- a/tests/expected_output/dimension_group_no_timeframes_test.lkml
+++ b/tests/expected_output/dimension_group_no_timeframes_test.lkml
@@ -1,0 +1,8 @@
+view: dimension_group_no_timeframes_test {
+
+  dimension_group: dimension1 {
+    type: time
+    datatype: datetime
+    sql: ${TABLE}.dim1 ;;
+  }
+}

--- a/tests/test_view.py
+++ b/tests/test_view.py
@@ -61,3 +61,19 @@ def test_dimension_group():
                            'expected_output/%s.lkml' % testname),
               'rt') as expected:
         assert lookml == expected.read()
+
+
+def test_dimension_group_no_timeframes():
+    testname = 'dimension_group_no_timeframes_test'
+    v = view.View(testname)
+    v.add_field(field.DimensionGroup('dimension1', sql='${TABLE}.dim1'))
+    f = six.StringIO()
+    fo_omit_timeframes = base_generator.\
+        GeneratorFormatOptions(warning_header_comment=None, omit_time_frames_if_not_set=True)
+    v.generate_lookml(f, format_options=fo_omit_timeframes)
+    lookml = f.getvalue()
+    six.print_(lookml)
+    with open(os.path.join(os.path.dirname(__file__),
+                           'expected_output/%s.lkml' % testname),
+              'rt') as expected:
+        assert lookml == expected.read()


### PR DESCRIPTION
`timeframe` parameters on  dimension_groups [are optional](https://looker.com/docs/reference/field-params/dimension_group), and for our company's use-case, we would like to omit the generation of a default `timeframes` parameter. 

I've added this as a new `GeneratorFormatOptions` option. I then had to modify the `DimensionGroup` class slightly to move the adding of the default timeframes to the `_generate` function so that it can be conditional on the formatting option. 

I included a test in the `test_view.py` file for this case.

Happy to change/tweak anything, thanks! 