### PR TITLE
Bug fix for extra newlines between field type sections

### DIFF
--- a/lookmlgen/view.py
+++ b/lookmlgen/view.py
@@ -54,6 +54,7 @@ class View(BaseGenerator):
             :class:`~lookmlgen.base_generator.GeneratorFormatOptions`
 
         """
+
         if not file and not self.file:
             raise ValueError('Must provide a file in either the constructor '
                              'or as a parameter to generate_lookml()')
@@ -78,13 +79,14 @@ class View(BaseGenerator):
                 f.write('\n')
 
         if fo.view_fields_alphabetical:
-            ordered_fields = sorted(self.fields.items())
+            self.__ordered_fields = sorted(self.fields.items())
         else:
-            ordered_fields = self.fields.items()
-        self._gen_fields(f, fo, ordered_fields, [FieldType.FILTER])
-        self._gen_fields(f, fo, ordered_fields,
-                         [FieldType.DIMENSION, FieldType.DIMENSION_GROUP])
-        self._gen_fields(f, fo, ordered_fields, [FieldType.MEASURE])
+            self.__ordered_fields = self.fields.items()
+        self.__generated_fields = []
+
+        self._gen_fields(f, fo, [FieldType.FILTER])
+        self._gen_fields(f, fo, [FieldType.DIMENSION, FieldType.DIMENSION_GROUP])
+        self._gen_fields(f, fo, [FieldType.MEASURE])
 
         f.write('}\n')
         return
@@ -100,17 +102,14 @@ class View(BaseGenerator):
         """
         self.derived_table = derived_table
 
-    @classmethod
-    def _gen_fields(cls, f, fo, sorted_fields, field_types):
-        first = True
-        for k, d in sorted_fields:
-            if not first and fo.newline_between_items:
-                f.write('\n')
+    def _gen_fields(self, f, fo, field_types):
+        for k, d in self.__ordered_fields:
             if d.field_type not in field_types:
                 continue
+            if len(self.__generated_fields) != 0 and fo.newline_between_items:
+                f.write('\n')
             d.generate_lookml(file=f, format_options=fo)
-            if first:
-                first = False
+            self.__generated_fields.append(d)
 
 
 class DerivedTable(BaseGenerator):

--- a/tests/expected_output/newlines_test.lkml
+++ b/tests/expected_output/newlines_test.lkml
@@ -1,0 +1,42 @@
+view: newlines_test {
+
+  dimension: a {
+    type: number
+    sql: ${TABLE}.a ;;
+  }
+
+  dimension: b {
+    type: number
+    sql: ${TABLE}.b ;;
+  }
+
+  dimension: c {
+    type: number
+    sql: ${TABLE}.c ;;
+  }
+
+  dimension: d {
+    type: number
+    sql: ${TABLE}.d ;;
+  }
+
+  measure: sum_a {
+    type: sum
+    sql: ${a} ;;
+  }
+
+  measure: sum_b {
+    type: sum
+    sql: ${b} ;;
+  }
+
+  measure: sum_c {
+    type: sum
+    sql: ${c} ;;
+  }
+
+  measure: sum_d {
+    type: sum
+    sql: ${d} ;;
+  }
+}

--- a/tests/test_view.py
+++ b/tests/test_view.py
@@ -77,3 +77,20 @@ def test_dimension_group_no_timeframes():
                            'expected_output/%s.lkml' % testname),
               'rt') as expected:
         assert lookml == expected.read()
+
+
+def test_newlines():
+    testname = 'newlines_test'
+    v = view.View(testname)
+    for l in ['a', 'b', 'c', 'd']:
+        v.add_field(field.Dimension(l, type='number'))
+        v.add_field(field.Measure('sum_' + l, type='sum', sql='${{{0}}}'.format(l)))
+
+    f = six.StringIO()
+    v.generate_lookml(f, format_options=test_format_options)
+    lookml = f.getvalue()
+    six.print_(lookml)
+    with open(os.path.join(os.path.dirname(__file__),
+                           'expected_output/%s.lkml' % testname),
+              'rt') as expected:
+        assert lookml == expected.read()


### PR DESCRIPTION
Fix for a small issue I ran into that introduced extra whitespace in between field type sections.

I noticed this when generating a view with many measures, the output will have a extra newline for each new measure, in between the dimensions and measures.

```yaml
view: newlines_test {

  dimension: a {
    type: number
    sql: ${TABLE}.a ;;
  }

  dimension: b {
    type: number
    sql: ${TABLE}.b ;;
  }

  dimension: c {
    type: number
    sql: ${TABLE}.c ;;
  }

  dimension: d {
    type: number
    sql: ${TABLE}.d ;;
  }




  measure: sum_a {
    type: sum
    sql: ${a} ;;
  }

  measure: sum_b {
    type: sum
    sql: ${b} ;;
  }

  measure: sum_c {
    type: sum
    sql: ${c} ;;
  }

  measure: sum_d {
    type: sum
    sql: ${d} ;;
  }
}
```

After some investigation, the problem seems to be in the logic in `View. _gen_fields` method that filters out fields to generate by type, but still outputs a newline even if the field is skipped.

 To fix the issue and still keep the logic to not output a newline if it's the very first field working, I refactored `__gen_fields` to be an instance method and keep track of how many fields have been processed using a `__generated_fields` list on the instance.  

Now a new line will only be added right before the field is generated, and we only skip it for the first field added to the view ( `len(self.__generated_fields) == 0`) 